### PR TITLE
Add basic docker-entrypoint.sh and support for existing sources

### DIFF
--- a/6.2/Dockerfile
+++ b/6.2/Dockerfile
@@ -6,12 +6,12 @@ RUN echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list
     echo "Package: *\\nPin: release n=jessie\\nPin-Priority: 900\\n\\nPackage: libpcre3*\\nPin: release n=stretch\\nPin-Priority: 1000" > /etc/apt/preferences && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        wget \
 # Configure PHP
-        libxml2-dev libfreetype6-dev \
+        libfreetype6-dev \
         libjpeg62-turbo-dev \
         libmcrypt-dev \
         libpng12-dev \
+        libxml2-dev \
         zlib1g-dev \
 # Install required 3rd party tools
         graphicsmagick && \
@@ -25,29 +25,25 @@ RUN echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list
 # Configure Apache as needed
     a2enmod rewrite && \
     apt-get clean && \
-    apt-get -y purge \
-        libxml2-dev libfreetype6-dev \
+    apt-get -y purge --auto-remove \
+        libfreetype6-dev \
         libjpeg62-turbo-dev \
         libmcrypt-dev \
         libpng12-dev \
+        libxml2-dev \
         zlib1g-dev && \
-    rm -rf /var/lib/apt/lists/* /usr/src/*
+    rm -rf /var/lib/apt/lists/*
 
-RUN cd /var/www/html && \
-    wget -O - https://get.typo3.org/6.2 | tar -xzf - && \
-    ln -s typo3_src-* typo3_src && \
-    ln -s typo3_src/index.php && \
-    ln -s typo3_src/typo3 && \
-    ln -s typo3_src/_.htaccess .htaccess && \
-    mkdir typo3temp && \
-    mkdir typo3conf && \
-    mkdir fileadmin && \
-    mkdir uploads && \
-    touch FIRST_INSTALL && \
-    chown -R www-data. .
+VOLUME /var/www/html
 
-# Configure volumes
-VOLUME /var/www/html/fileadmin
-VOLUME /var/www/html/typo3conf
-VOLUME /var/www/html/typo3temp
-VOLUME /var/www/html/uploads
+RUN set -ex; \
+    curl -o typo3.tar.gz -fSL https://get.typo3.org/6.2; \
+    mkdir /usr/src/typo3; \
+    tar -xzf typo3.tar.gz -C /usr/src/typo3; \
+    rm typo3.tar.gz; \
+    chown -R www-data:www-data /usr/src/typo3
+
+COPY docker-entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/6.2/docker-entrypoint.sh
+++ b/6.2/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+	if ! [ -e index.php -a -e typo3/index.php ]; then
+		echo >&2 "TYPO3 not found in $PWD - copying now..."
+		if [ "$(ls -A)" ]; then
+			echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
+			( set -x; ls -A; sleep 10 )
+		fi
+		tar cf - --one-file-system -C /usr/src/typo3 . | tar xf -
+		ln -s typo3_src-* typo3_src
+		ln -s typo3_src/index.php
+		ln -s typo3_src/typo3
+		ln -s typo3_src/_.htaccess .htaccess
+		touch FIRST_INSTALL
+		chown -R www-data:www-data FIRST_INSTALL
+		echo >&2 "Complete! TYPO3 has been successfully copied to $PWD"
+	fi
+fi
+
+exec "$@"

--- a/7.6/Dockerfile
+++ b/7.6/Dockerfile
@@ -6,12 +6,12 @@ RUN echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list
     echo "Package: *\\nPin: release n=jessie\\nPin-Priority: 900\\n\\nPackage: libpcre3*\\nPin: release n=stretch\\nPin-Priority: 1000" > /etc/apt/preferences && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        wget \
 # Configure PHP
-        libxml2-dev libfreetype6-dev \
+        libfreetype6-dev \
         libjpeg62-turbo-dev \
         libmcrypt-dev \
         libpng12-dev \
+        libxml2-dev \
         zlib1g-dev \
 # Install required 3rd party tools
         graphicsmagick && \
@@ -25,29 +25,25 @@ RUN echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list
 # Configure Apache as needed
     a2enmod rewrite && \
     apt-get clean && \
-    apt-get -y purge \
-        libxml2-dev libfreetype6-dev \
+    apt-get -y purge --auto-remove \
+        libfreetype6-dev \
         libjpeg62-turbo-dev \
         libmcrypt-dev \
         libpng12-dev \
+        libxml2-dev \
         zlib1g-dev && \
-    rm -rf /var/lib/apt/lists/* /usr/src/*
+    rm -rf /var/lib/apt/lists/*
 
-RUN cd /var/www/html && \
-    wget -O - https://get.typo3.org/7.6 | tar -xzf - && \
-    ln -s typo3_src-* typo3_src && \
-    ln -s typo3_src/index.php && \
-    ln -s typo3_src/typo3 && \
-    ln -s typo3_src/_.htaccess .htaccess && \
-    mkdir typo3temp && \
-    mkdir typo3conf && \
-    mkdir fileadmin && \
-    mkdir uploads && \
-    touch FIRST_INSTALL && \
-    chown -R www-data. .
+VOLUME /var/www/html
 
-# Configure volumes
-VOLUME /var/www/html/fileadmin
-VOLUME /var/www/html/typo3conf
-VOLUME /var/www/html/typo3temp
-VOLUME /var/www/html/uploads
+RUN set -ex; \
+    curl -o typo3.tar.gz -fSL https://get.typo3.org/7.6; \
+    mkdir /usr/src/typo3; \
+    tar -xzf typo3.tar.gz -C /usr/src/typo3; \
+    rm typo3.tar.gz; \
+    chown -R www-data:www-data /usr/src/typo3
+
+COPY docker-entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/7.6/docker-entrypoint.sh
+++ b/7.6/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+	if ! [ -e index.php -a -e typo3/index.php ]; then
+		echo >&2 "TYPO3 not found in $PWD - copying now..."
+		if [ "$(ls -A)" ]; then
+			echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
+			( set -x; ls -A; sleep 10 )
+		fi
+		tar cf - --one-file-system -C /usr/src/typo3 . | tar xf -
+		ln -s typo3_src-* typo3_src
+		ln -s typo3_src/index.php
+		ln -s typo3_src/typo3
+		ln -s typo3_src/_.htaccess .htaccess
+		touch FIRST_INSTALL
+		chown -R www-data:www-data FIRST_INSTALL
+		echo >&2 "Complete! TYPO3 has been successfully copied to $PWD"
+	fi
+fi
+
+exec "$@"

--- a/8.7/Dockerfile
+++ b/8.7/Dockerfile
@@ -4,12 +4,12 @@ LABEL maintainer="Martin Helmich <typo3@martin-helmich.de>"
 # Install TYPO3
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-        wget \
 # Configure PHP
-        libxml2-dev libfreetype6-dev \
+        libfreetype6-dev \
         libjpeg62-turbo-dev \
         libmcrypt-dev \
         libpng-dev \
+        libxml2-dev \
         zlib1g-dev \
 # Install required 3rd party tools
         graphicsmagick && \
@@ -20,29 +20,25 @@ RUN apt-get update && \
 # Configure Apache as needed
     a2enmod rewrite && \
     apt-get clean && \
-    apt-get -y purge \
-        libxml2-dev libfreetype6-dev \
+    apt-get -y purge --auto-remove \
+        libfreetype6-dev \
         libjpeg62-turbo-dev \
         libmcrypt-dev \
         libpng12-dev \
+        libxml2-dev \
         zlib1g-dev && \
-    rm -rf /var/lib/apt/lists/* /usr/src/*
+    rm -rf /var/lib/apt/lists/*
 
-RUN cd /var/www/html && \
-    wget -O - https://get.typo3.org/8.7 | tar -xzf - && \
-    ln -s typo3_src-* typo3_src && \
-    ln -s typo3_src/index.php && \
-    ln -s typo3_src/typo3 && \
-    ln -s typo3_src/_.htaccess .htaccess && \
-    mkdir typo3temp && \
-    mkdir typo3conf && \
-    mkdir fileadmin && \
-    mkdir uploads && \
-    touch FIRST_INSTALL && \
-    chown -R www-data. .
+VOLUME /var/www/html
 
-# Configure volumes
-VOLUME /var/www/html/fileadmin
-VOLUME /var/www/html/typo3conf
-VOLUME /var/www/html/typo3temp
-VOLUME /var/www/html/uploads
+RUN set -ex; \
+    curl -o typo3.tar.gz -fSL https://get.typo3.org/8.7; \
+    mkdir /usr/src/typo3; \
+    tar -xzf typo3.tar.gz -C /usr/src/typo3; \
+    rm typo3.tar.gz; \
+    chown -R www-data:www-data /usr/src/typo3
+
+COPY docker-entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/8.7/docker-entrypoint.sh
+++ b/8.7/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+	if ! [ -e index.php -a -e typo3/index.php ]; then
+		echo >&2 "TYPO3 not found in $PWD - copying now..."
+		if [ "$(ls -A)" ]; then
+			echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
+			( set -x; ls -A; sleep 10 )
+		fi
+		tar cf - --one-file-system -C /usr/src/typo3 . | tar xf -
+		ln -s typo3_src-* typo3_src
+		ln -s typo3_src/index.php
+		ln -s typo3_src/typo3
+		ln -s typo3_src/_.htaccess .htaccess
+		touch FIRST_INSTALL
+		chown -R www-data:www-data FIRST_INSTALL
+		echo >&2 "Complete! TYPO3 has been successfully copied to $PWD"
+	fi
+fi
+
+exec "$@"

--- a/Dockerfile.in
+++ b/Dockerfile.in
@@ -6,12 +6,12 @@ RUN echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list
     echo "Package: *\\nPin: release n=jessie\\nPin-Priority: 900\\n\\nPackage: libpcre3*\\nPin: release n=stretch\\nPin-Priority: 1000" > /etc/apt/preferences && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-        wget \
 # Configure PHP
-        libxml2-dev libfreetype6-dev \
+        libfreetype6-dev \
         libjpeg62-turbo-dev \
         libmcrypt-dev \
         libpng12-dev \
+        libxml2-dev \
         zlib1g-dev \
 # Install required 3rd party tools
         graphicsmagick && \
@@ -25,29 +25,25 @@ RUN echo "deb http://deb.debian.org/debian stretch main" > /etc/apt/sources.list
 # Configure Apache as needed
     a2enmod rewrite && \
     apt-get clean && \
-    apt-get -y purge \
-        libxml2-dev libfreetype6-dev \
+    apt-get -y purge --auto-remove \
+        libfreetype6-dev \
         libjpeg62-turbo-dev \
         libmcrypt-dev \
         libpng12-dev \
+        libxml2-dev \
         zlib1g-dev && \
-    rm -rf /var/lib/apt/lists/* /usr/src/*
+    rm -rf /var/lib/apt/lists/*
 
-RUN cd /var/www/html && \
-    wget -O - https://get.typo3.org/TYPOVER | tar -xzf - && \
-    ln -s typo3_src-* typo3_src && \
-    ln -s typo3_src/index.php && \
-    ln -s typo3_src/typo3 && \
-    ln -s typo3_src/_.htaccess .htaccess && \
-    mkdir typo3temp && \
-    mkdir typo3conf && \
-    mkdir fileadmin && \
-    mkdir uploads && \
-    touch FIRST_INSTALL && \
-    chown -R www-data. .
+VOLUME /var/www/html
 
-# Configure volumes
-VOLUME /var/www/html/fileadmin
-VOLUME /var/www/html/typo3conf
-VOLUME /var/www/html/typo3temp
-VOLUME /var/www/html/uploads
+RUN set -ex; \
+    curl -o typo3.tar.gz -fSL https://get.typo3.org/TYPOVER; \
+    mkdir /usr/src/typo3; \
+    tar -xzf typo3.tar.gz -C /usr/src/typo3; \
+    rm typo3.tar.gz; \
+    chown -R www-data:www-data /usr/src/typo3
+
+COPY docker-entrypoint.sh /usr/local/bin/
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD ["apache2-foreground"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+set -euo pipefail
+
+if [[ "$1" == apache2* ]] || [ "$1" == php-fpm ]; then
+	if ! [ -e index.php -a -e typo3/index.php ]; then
+		echo >&2 "TYPO3 not found in $PWD - copying now..."
+		if [ "$(ls -A)" ]; then
+			echo >&2 "WARNING: $PWD is not empty - press Ctrl+C now if this is an error!"
+			( set -x; ls -A; sleep 10 )
+		fi
+		tar cf - --one-file-system -C /usr/src/typo3 . | tar xf -
+		ln -s typo3_src-* typo3_src
+		ln -s typo3_src/index.php
+		ln -s typo3_src/typo3
+		ln -s typo3_src/_.htaccess .htaccess
+		touch FIRST_INSTALL
+		chown -R www-data:www-data FIRST_INSTALL
+		echo >&2 "Complete! TYPO3 has been successfully copied to $PWD"
+	fi
+fi
+
+exec "$@"


### PR DESCRIPTION
This add an entrypoint to the TYPO3 image to support both: existing sources and new installations. Previously it was hard to migrate existing installations to Docker. It's now to mount a whole  installation to `/var/www/html`, but it's still possible to mount only parts like `/var/www/html/typo3conf`.

This makes this image to behave more like other images in the official Docker library, e.g. [Drupal](https://github.com/docker-library/drupal), [Joomla](https://github.com/joomla/docker-joomla) or [Wordpress](https://github.com/docker-library/wordpress). 