### PR TITLE
Copy root-htaccess to _.htaccess and create a link

### DIFF
--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -33,6 +33,9 @@ RUN cd /var/www/html && \
     ln -s typo3_src-* typo3_src && \
     ln -s typo3_src/index.php && \
     ln -s typo3_src/typo3 && \
+    cp typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/root-htaccess typo3_src && \
+    mv typo3_src/root-htaccess typo3_src/_.htaccess && \
+    ln -s typo3_src/_.htaccess .htaccess && \
     mkdir typo3temp && \
     mkdir typo3conf && \
     mkdir fileadmin && \


### PR DESCRIPTION
Due to these changes:
https://docs.typo3.org/typo3cms/extensions/core/Changelog/9.5/Important-86173-LocationOfSuppliedHtaccessWebconfigFilesChanged.html

It is necessary to copy the root-htaccess and create a link to provide the ability of namebased urls and other features like "deny all" of several directories etc.

The .htaccess-file should not be generated within the installation process because the installation would be required always when the docker container is destroyed or just upped.