### PR TITLE
Remove linking the .htaccess file for TYPO3 Version >= 9.5

### DIFF
--- a/9.5/Dockerfile
+++ b/9.5/Dockerfile
@@ -33,8 +33,6 @@ RUN cd /var/www/html && \
     ln -s typo3_src-* typo3_src && \
     ln -s typo3_src/index.php && \
     ln -s typo3_src/typo3 && \
-    cp typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/root-htaccess typo3_src/_.htaccess && \
-    ln -s typo3_src/_.htaccess .htaccess && \
     mkdir typo3temp && \
     mkdir typo3conf && \
     mkdir fileadmin && \

--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,4 @@ all: $(DOCKERFILES)
 	sed -e 's/PHPVER/7.2/' -e 's/TYPOVER/9.4/' $< > $@
 
 9.5/Dockerfile: Dockerfile.in
-	sed -e 's/PHPVER/7.2/' -e 's/TYPOVER/9.5/' $< > $@
+	sed -e 's/PHPVER/7.2/' -e 's/TYPOVER/9.5/' -e '/_.htaccess/d' $< > $@


### PR DESCRIPTION
The .htaccess file is created automatically during the TYPO3 installation process since TYPO3 Version 9.5

[Important: #86173 - Location of supplied .htaccess / web.config files changed](https://docs.typo3.org/typo3cms/extensions/core/Changelog/9.5/Important-86173-LocationOfSuppliedHtaccessWebconfigFilesChanged.html)