### PR TITLE
Downloadlink needs full semantic versioning

### DIFF
--- a/10.1/Dockerfile
+++ b/10.1/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /usr/src/*
 
 RUN cd /var/www/html && \
-    wget -O - https://get.typo3.org/10.1 | tar -xzf - && \
+    wget -O - https://get.typo3.org/10.1.0 | tar -xzf - && \
     ln -s typo3_src-* typo3_src && \
     ln -s typo3_src/index.php && \
     ln -s typo3_src/typo3 && \


### PR DESCRIPTION
The Typo3 links need full version like
https://get.typo3.org/10.1.0
otherwise you build with the latest version e.g. https://get.typo3.org/10.1 downloads 10.2.2 at the moment.