### PR TITLE
correct link for downloading TYPO3 in 10.2 Dockerfile

### DIFF
--- a/10.2/Dockerfile
+++ b/10.2/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && \
     rm -rf /var/lib/apt/lists/* /usr/src/*
 
 RUN cd /var/www/html && \
-    wget -O - https://get.typo3.org/10.1 | tar -xzf - && \
+    wget -O - https://get.typo3.org/10.2 | tar -xzf - && \
     ln -s typo3_src-* typo3_src && \
     ln -s typo3_src/index.php && \
     ln -s typo3_src/typo3 && \


### PR DESCRIPTION
10.2 instead of 10.1