### PR TITLE
Add typo3 12.3 Dockerfile and compose

### DIFF
--- a/12.3/Dockerfile
+++ b/12.3/Dockerfile
@@ -1,0 +1,73 @@
+# Docker image for TYPO3 CMS
+# Copyright (C) 2016-2020  Martin Helmich <martin@helmich.me>
+#                          and contributors <https://github.com/martin-helmich/docker-typo3/graphs/contributors>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+FROM php:8.2-apache-buster
+LABEL maintainer="Martin Helmich <typo3@martin-helmich.de>"
+
+# Install TYPO3
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y --no-install-recommends \
+        wget \
+# Configure PHP
+        libxml2-dev libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libmcrypt-dev \
+        libpng-dev \
+        libpq-dev \
+        libzip-dev \
+        zlib1g-dev \
+# Install required 3rd party tools
+        graphicsmagick && \
+# Configure extensions
+    docker-php-ext-configure gd --with-libdir=/usr/include/ --with-jpeg --with-freetype && \
+    docker-php-ext-install -j$(nproc) mysqli soap gd zip opcache intl pgsql pdo_pgsql && \
+    echo 'always_populate_raw_post_data = -1\nmax_execution_time = 240\nmax_input_vars = 1500\nupload_max_filesize = 32M\npost_max_size = 32M' > /usr/local/etc/php/conf.d/typo3.ini && \
+# Configure Apache as needed
+    a2enmod rewrite && \
+    apt-get clean && \
+    apt-get -y purge \
+        libxml2-dev libfreetype6-dev \
+        libjpeg62-turbo-dev \
+        libmcrypt-dev \
+        libpng-dev \
+        libzip-dev \
+        zlib1g-dev && \
+    rm -rf /var/lib/apt/lists/* /usr/src/*
+
+RUN cd /var/www/html && \
+    wget -O download.tar.gz https://get.typo3.org/12.3.0 && \
+    echo "6c1659d1da9ee0298604814c1d4e3c7cc70f3e8364bb2f70eecb0133262d4d6f download.tar.gz" > download.tar.gz.sum && \
+    sha256sum -c download.tar.gz.sum && \
+    tar -xzf download.tar.gz && \
+    rm download.* && \
+    ln -s typo3_src-* typo3_src && \
+    ln -s typo3_src/index.php && \
+    ln -s typo3_src/typo3 && \
+    cp typo3/sysext/install/Resources/Private/FolderStructureTemplateFiles/root-htaccess .htaccess && \
+    mkdir typo3temp && \
+    mkdir typo3conf && \
+    mkdir fileadmin && \
+    mkdir uploads && \
+    touch FIRST_INSTALL && \
+    chown -R www-data. .
+
+# Configure volumes
+VOLUME /var/www/html/fileadmin
+VOLUME /var/www/html/typo3conf
+VOLUME /var/www/html/typo3temp
+VOLUME /var/www/html/uploads

--- a/12.3/docker-compose.yml
+++ b/12.3/docker-compose.yml
@@ -1,0 +1,48 @@
+# Docker image for TYPO3 CMS
+# Copyright (C) 2016-2020  Martin Helmich <martin@helmich.me>
+#                          and contributors <https://github.com/martin-helmich/docker-typo3/graphs/contributors>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+version: "3"
+services:
+  typo3:
+    build: .
+    ports:
+      - "80:80"
+    volumes:
+      - fileadmin:/var/www/html/fileadmin
+      - typo3conf:/var/www/html/typo3conf
+      - uploads:/var/www/html/uploads
+    networks:
+      - backend
+  database:
+    image: mysql:8.0
+    command:
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci
+    environment:
+      - "MYSQL_USER=${MYSQL_USER:-typo3}"
+      - "MYSQL_PASSWORD=${MYSQL_PASSWORD:-password}"
+      - "MYSQL_DATABASE=${MYSQL_DATABASE:-typo3}"
+      - "MYSQL_RANDOM_ROOT_PASSWORD=yes"
+    networks:
+      - backend
+volumes:
+  database:
+  fileadmin:
+  typo3conf:
+  uploads:
+networks:
+  backend:


### PR DESCRIPTION
Hello,

this adds the 12.3.0 Dockerfile and the compose.

I had to change the charset of the database to 
```
      - --character-set-server=utf8mb4
      - --collation-server=utf8mb4_unicode_ci
```
to get it running. 


Greetings