### PR TITLE
fix: "latest" tag should be v13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,6 +35,6 @@ jobs:
           docker buildx build -t ${{ secrets.DOCKERHUB_USER }}/typo3:$VERSION --platform linux/arm/v7,linux/arm64/v8,linux/amd64 --push .
           docker buildx imagetools create ${{ secrets.DOCKERHUB_USER }}/typo3:$VERSION --tag ${{ secrets.DOCKERHUB_USER }}/typo3:$MAJOR
 
-          if [[ ${MAJOR} -eq 12 ]] ; then
+          if [[ ${MAJOR} -eq 13 ]] ; then
             docker buildx imagetools create ${{ secrets.DOCKERHUB_USER }}/typo3:$VERSION --tag ${{ secrets.DOCKERHUB_USER }}/typo3:latest
           fi


### PR DESCRIPTION
This PR fixes a bug in the pipeline, which still causes the `latest` tag to point to the v12 release (instead of the v13 release, as it should be since #313).
