### PR TITLE
docs: add sections on mounted volumes and exposed ports for TYPO3 Doc…

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,31 @@ This container does not ship a database management system; which means you'll ha
 4. Complete the install tool. When prompted for database credentials, use the environment variables that you've passed to the database container in step 1. If you've linked the containers using the `--link` flag as shown in step 2, use `db` as database host name.
 
  ![](doc/database-setup.png)
+ 
+Volumes to be Mounted
+~~~~~~~~~~~~~~~~~~~~~
+
+The Docker images expose the following volumes, which **should** be mounted to ensure proper functionality and data persistence:
+
+- `/var/www/html/fileadmin` — Contains files and images uploaded by editors.
+- `/var/www/html/typo3conf` — Contains uploaded extensions, configuration, and language files.
+- `/var/www/html/typo3temp` — Contains temporary files such as logs that may be useful for debugging.
+- `/var/www/html/uploads` — Deprecated since TYPO3 6.2 and unused after TYPO3 10.0. Can be ignored for newer installations.
+
+If you are using the supplied `docker-compose.yml` file, these volumes are mounted automatically.
+
+If you are using a custom configuration strategy, you must ensure these volumes are mounted manually.
+
+Exposed Ports and Reverse Proxies
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The Docker image exposes **port 80**. If you are using the provided `docker-compose.yml`, this is automatically mapped to port 80 on your host system, allowing you to access the site at [http://localhost](http://localhost).
+
+If you are using a different setup, you may need to manually map port 80 to a suitable host port.
+
+If you plan to use HTTPS/TLS, you must additionally configure your reverse proxy. For more details, refer to the TYPO3 documentation:  
+[Reverse Proxy Container Configuration](https://docs.typo3.org/permalink/t3coreapi:reverse-proxy-container)
+
 
 Special use cases
 -----------------


### PR DESCRIPTION
…ker image

This commit adds two new sections to the README:

- **Volumes to be Mounted**: Describes the Docker volumes exposed by the TYPO3 container and their purposes.
- **Exposed Ports and Reverse Proxies**: Explains port mappings and provides guidance on reverse proxy configuration for HTTPS/TLS.

These additions aim to improve clarity for users setting up TYPO3 via Docker, especially when using custom setups beyond the provided `docker-compose.yml`.